### PR TITLE
Open cycling map by default (until transit is developed) + better default zoom

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -49,7 +49,9 @@ function App() {
           <Route path="/walking">
             <WalkingMap />
           </Route>
-          <Route path="/"></Route>
+          <Route path="/">
+            <Redirect to="/cycling" />
+          </Route>
           <Route>
             {/* Not found */}
             <Redirect to="/" />

--- a/web-ui/src/Map/Map.tsx
+++ b/web-ui/src/Map/Map.tsx
@@ -46,19 +46,19 @@ export const Map: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       parseFloat(initialUrl.searchParams.get("z") ?? ""),
       5,
       20,
-      10,
+      13,
     );
     const initialLng = constrain(
       parseFloat(initialUrl.searchParams.get("lng") ?? ""),
       -140,
       -115,
-      -122.94536684722912,
+      -123.135,
     );
     const initialLat = constrain(
       parseFloat(initialUrl.searchParams.get("lat") ?? ""),
       47,
       60,
-      49.241584389313424,
+      49.272,
     );
 
     const map = new maplibregl.Map({


### PR DESCRIPTION
When you go to www.transitopia.org, you currently see very little of interest. Let's activate the cycling map by default, since it's the only one that's been developed.

Also, the current default map is too zoomed out. I'm increasing the default zoom so you can see more interesting things right away.