### PR TITLE
Downgrade bike lane segments with dooring risk from adjacent parking

### DIFF
--- a/web-ui/src/CyclingMap/CyclingMap.tsx
+++ b/web-ui/src/CyclingMap/CyclingMap.tsx
@@ -215,6 +215,13 @@ export const CyclingMap: React.FC = () => {
                 </span>
               )
               : null}
+            {selectedFeature.dooring_risk
+              ? (
+                <span className="inline-block m-1 px-1 rounded-md bg-red-600 text-white">
+                  risk of dooring (adjacent parking)
+                </span>
+              )
+              : null}
             {selectedFeature.shared_with_vehicles
               ? (
                 <span className="inline-block m-1 px-1 rounded-md bg-red-600 text-white">

--- a/web-ui/src/Map/MapData.ts
+++ b/web-ui/src/Map/MapData.ts
@@ -8,6 +8,7 @@ export interface MapCyclingElement {
   construction?: boolean;
   shared_with_pedestrians: boolean;
   shared_with_vehicles: boolean;
+  dooring_risk?: boolean;
   surface?: string;
   class: "lane" | "track";
   comfort: 4 | 3 | 2 | 1;


### PR DESCRIPTION
Closes https://github.com/transitopia/transitopia/issues/20

<img width="453" height="382" alt="Screenshot 2025-08-15 at 11 14 42 PM" src="https://github.com/user-attachments/assets/52a4c5c2-ffe4-4b48-a10a-92575d56f5bb" />


Known issues: one bike lane, Yukon Street, e.g. https://www.openstreetmap.org/way/1386156266 , is being incorrectly flagged as a dooring risk because it has on-street parking, but it has a painted buffer between the bike lane and the parking area. Unfortunately [`cycleway:buffer`](https://wiki.openstreetmap.org/wiki/Key:cycleway:buffer) doesn't help identify a buffer in this case. We probably need something like [`cycleway:left:separation:left`](https://wiki.openstreetmap.org/wiki/Proposal:Separation) but that doesn't seem to have much adoption.