### PR TITLE
feat: get cycling track/lane names from the Transitopia layer, not base map

### DIFF
--- a/web-ui/src/CyclingMap/cycling-map-layers.ts
+++ b/web-ui/src/CyclingMap/cycling-map-layers.ts
@@ -4,10 +4,7 @@
 // Design license: CC-BY 4.0 https://creativecommons.org/licenses/by/4.0/
 
 import type { ExpressionSpecification, LayerSpecification } from "maplibre-gl";
-import {
-  defaultLineLayout,
-  interpolateZoom,
-} from "../Map/basemap-layers.ts";
+import { defaultLineLayout, interpolateZoom } from "../Map/basemap-layers.ts";
 
 // Which map "source" file (which .pmtiles file) the cycling data layers are found in
 export const mapSource = "transitopia-cycling";
@@ -217,6 +214,7 @@ export const layers: LayerSpecification[] = [
       ["==", "$type", "LineString"],
       ["any", ["==", "class", "track"], ["==", "class", "lane"]],
       ["has", "name"],
+      [">=", "comfort", 2],
     ],
     "layout": {
       "symbol-placement": "line",

--- a/web-ui/src/CyclingMap/cycling-map-layers.ts
+++ b/web-ui/src/CyclingMap/cycling-map-layers.ts
@@ -7,7 +7,6 @@ import type { ExpressionSpecification, LayerSpecification } from "maplibre-gl";
 import {
   defaultLineLayout,
   interpolateZoom,
-  mapSource as baseMapSource,
 } from "../Map/basemap-layers.ts";
 
 // Which map "source" file (which .pmtiles file) the cycling data layers are found in
@@ -211,19 +210,18 @@ export const layers: LayerSpecification[] = [
   {
     id: "cycling_path_name",
     type: "symbol",
-    // TODO: move the cycling path names into our Transitopia cycling layer
-    source: baseMapSource,
-    "source-layer": "transportation_name",
+    source: mapSource,
+    "source-layer": "transitopia_cycling",
     "filter": [
       "all",
-      ["!=", "class", "motorway"],
       ["==", "$type", "LineString"],
-      ["==", "subclass", "cycleway"],
+      ["any", ["==", "class", "track"], ["==", "class", "lane"]],
+      ["has", "name"],
     ],
     "layout": {
       "symbol-placement": "line",
       "symbol-spacing": 350,
-      "text-field": "{name:latin} {name:nonlatin}",
+      "text-field": "{name}",
       "text-font": ["Metropolis Regular"],
       "text-max-angle": 30,
       "text-pitch-alignment": "viewport",


### PR DESCRIPTION
Our cycling layer already has the names of all the bike tracks/lanes, so use that data to label the cycling paths. This actually results in a lot nicer map, with the bike lanes labelled much more clearly (more labels show up):

## Before

<img width="1028" height="511" alt="before" src="https://github.com/user-attachments/assets/387add69-3dc4-4c38-ab7d-2b5bbedc894b" />

## After

<img width="1032" height="512" alt="after" src="https://github.com/user-attachments/assets/303d777d-b12f-4733-a445-7ba1a3574f4e" />

Closes #4 