### PR TITLE
Generate Cycling Map Layers from JS code that is shared with the frontend

### DIFF
--- a/common-lib/package-lock.json
+++ b/common-lib/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "transitopia-lib",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transitopia-lib",
+      "devDependencies": {
+        "@types/node": "^24.3.0"
+      },
+      "peerDependencies": {
+        "zod": "4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/common-lib/package-lock.json
+++ b/common-lib/package-lock.json
@@ -6,10 +6,414 @@
     "": {
       "name": "transitopia-lib",
       "devDependencies": {
-        "@types/node": "^24.3.0"
+        "@types/node": "^24.3.0",
+        "tsdown": "^0.14.1"
       },
       "peerDependencies": {
         "zod": "4"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
+      "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.5",
+        "@emnapi/runtime": "^1.4.5",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.82.2",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.82.2.tgz",
+      "integrity": "sha512-cYxcj5CPn/vo5QSpCZcYzBiLidU5+GlFSqIeNaMgBDtcVRBsBJHZg3pHw999W6nHamFQ1EHuPPByB26tjaJiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.82.2",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.82.2.tgz",
+      "integrity": "sha512-WMGSwd9FsNBs/WfqIOH0h3k1LBdjZJQGYjGnC+vla/fh6HUsu5HzGPerRljiq1hgMQ6gs031YJR12VyP57b/hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@quansync/fs": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-0.1.5.tgz",
+      "integrity": "sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.33.tgz",
+      "integrity": "sha512-xhDQXKftRkEULIxCddrKMR8y0YO/Y+6BKk/XrQP2B29YjV2wr8DByoEz+AHX9BfLHb2srfpdN46UquBW2QXWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.33.tgz",
+      "integrity": "sha512-7lhhY08v5ZtRq8JJQaJ49fnJombAPnqllKKCDLU/UvaqNAOEyTGC8J1WVOLC4EA4zbXO5U3CCRgVGyAFNH2VtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.33.tgz",
+      "integrity": "sha512-U2iGjcDV7NWyYyhap8YuY0nwrLX6TvX/9i7gBtdEMPm9z3wIUVGNMVdGlA43uqg7xDpRGpEqGnxbeDgiEwYdnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.33.tgz",
+      "integrity": "sha512-gd6ASromVHFLlzrjJWMG5CXHkS7/36DEZ8HhvGt2NN8eZALCIuyEx8HMMLqvKA7z4EAztVkdToVrdxpGMsKZxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.33.tgz",
+      "integrity": "sha512-xmeLfkfGthuynO1EpCdyTVr0r4G+wqvnKCuyR6rXOet+hLrq5HNAC2XtP/jU2TB4Bc6aiLYxl868B8CGtFDhcw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.33.tgz",
+      "integrity": "sha512-cHGp8yfHL4pes6uaLbO5L58ceFkUK4efd8iE86jClD1QPPDLKiqEXJCFYeuK3OfODuF5EBOmf0SlcUZNEYGdmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.33.tgz",
+      "integrity": "sha512-wZ1t7JAvVeFgskH1L9y7c47ITitPytpL0s8FmAT8pVfXcaTmS58ZyoXT+y6cz8uCkQnETjrX3YezTGI18u3ecg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.33.tgz",
+      "integrity": "sha512-cDndWo3VEYbm7yeujOV6Ie2XHz0K8YX/R/vbNmMo03m1QwtBKKvbYNSyJb3B9+8igltDjd8zNM9mpiNNrq/ekQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.33.tgz",
+      "integrity": "sha512-bl7uzi6es/l6LT++NZcBpiX43ldLyKXCPwEZGY1rZJ99HQ7m1g3KxWwYCcGxtKjlb2ExVvDZicF6k+96vxOJKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.33.tgz",
+      "integrity": "sha512-TrgzQanpLgcmmzolCbYA9BPZgF1gYxkIGZhU/HROnJPsq67gcyaYw/JBLioqQLjIwMipETkn25YY799D2OZzJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.33.tgz",
+      "integrity": "sha512-z0LltdUfvoKak9SuaLz/M9AVSg+RTOZjFksbZXzC6Svl1odyW4ai21VHhZy3m2Faeeb/rl/9efVLayj+qYEGxw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.33.tgz",
+      "integrity": "sha512-CpvOHyqDNOYx9riD4giyXQDIu72bWRU2Dwt1xFSPlBudk6NumK0OJl6Ch+LPnkp5podQHcQg0mMauAXPVKct7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rolldown/binding-win32-ia32-msvc": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.33.tgz",
+      "integrity": "sha512-/tNTvZTWHz6HiVuwpR3zR0kGIyCNb+/tFhnJmti+Aw2fAXs3l7Aj0DcXd0646eFKMX8L2w5hOW9H08FXTUkN0g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.33.tgz",
+      "integrity": "sha512-Bb2qK3z7g2mf4zaKRvkohHzweaP1lLbaoBmXZFkY6jJWMm0Z8Pfnh8cOoRlH1IVM1Ufbo8ZZ1WXp1LbOpRMtXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.33.tgz",
+      "integrity": "sha512-she25NCG6NoEPC/SEB4pHs5STcnfI4VBFOzjeI63maSPrWME5J2XC8ogrBgp8NaE/xzj28/kbpSaebiMvFRj+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/node": {
@@ -20,6 +424,463 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
+      "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ast-kit": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
+      "integrity": "sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.5.0.tgz",
+      "integrity": "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dts-resolver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.1.tgz",
+      "integrity": "sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "oxc-resolver": ">=11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.33.tgz",
+      "integrity": "sha512-mgu118ZuRguC8unhPCbdZbyRbjQfEMiWqlojBA5aRIncBelRaBomnHNpGKYkYWeK7twRz5Cql30xgqqrA3Xelw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "=0.82.2",
+        "@oxc-project/types": "=0.82.2",
+        "@rolldown/pluginutils": "1.0.0-beta.33",
+        "ansis": "^4.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-beta.33",
+        "@rolldown/binding-darwin-arm64": "1.0.0-beta.33",
+        "@rolldown/binding-darwin-x64": "1.0.0-beta.33",
+        "@rolldown/binding-freebsd-x64": "1.0.0-beta.33",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.33",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.33",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.33",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.33",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-beta.33",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-beta.33",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-beta.33",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.33",
+        "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.33",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.33"
+      }
+    },
+    "node_modules/rolldown-plugin-dts": {
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.15.6.tgz",
+      "integrity": "sha512-AxQlyx3Nszob5QLmVUjz/VnC5BevtUo0h8tliuE0egddss7IbtCBU7GOe7biRU0fJNRQJmQjPKXFcc7K98j3+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "ast-kit": "^2.1.1",
+        "birpc": "^2.5.0",
+        "debug": "^4.4.1",
+        "dts-resolver": "^2.1.1",
+        "get-tsconfig": "^4.10.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@typescript/native-preview": ">=7.0.0-dev.20250601.1",
+        "rolldown": "^1.0.0-beta.9",
+        "typescript": "^5.0.0",
+        "vue-tsc": "~3.0.3"
+      },
+      "peerDependenciesMeta": {
+        "@typescript/native-preview": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tsdown": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.14.1.tgz",
+      "integrity": "sha512-/nBuFDKZeYln9hAxwWG5Cm55/823sNIVI693iVi0xRFHzf9OVUq4b/lx9PH1TErFr/IQ0kd2hutFbJIPM0XQWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^4.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "debug": "^4.4.1",
+        "diff": "^8.0.2",
+        "empathic": "^2.0.0",
+        "hookable": "^5.5.3",
+        "rolldown": "latest",
+        "rolldown-plugin-dts": "^0.15.6",
+        "semver": "^7.7.2",
+        "tinyexec": "^1.0.1",
+        "tinyglobby": "^0.2.14",
+        "tree-kill": "^1.2.2",
+        "unconfig": "^7.3.2"
+      },
+      "bin": {
+        "tsdown": "dist/run.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.1",
+        "publint": "^0.3.0",
+        "typescript": "^5.0.0",
+        "unplugin-lightningcss": "^0.4.0",
+        "unplugin-unused": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "unplugin-lightningcss": {
+          "optional": true
+        },
+        "unplugin-unused": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/unconfig": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.3.2.tgz",
+      "integrity": "sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@quansync/fs": "^0.1.1",
+        "defu": "^6.1.4",
+        "jiti": "^2.4.2",
+        "quansync": "^0.2.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/undici-types": {

--- a/common-lib/package.json
+++ b/common-lib/package.json
@@ -1,13 +1,23 @@
 {
   "name": "transitopia-lib",
+  "exports": {
+    "./FeatureId": {
+      "import": "./src/FeatureId.ts"
+    },
+    "./MapFeatures": {
+      "import": "./src/MapFeatures.ts"
+    }
+  },
   "peerDependencies": {
     "zod": "4"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0"
+    "@types/node": "^24.3.0",
+    "tsdown": "^0.14.1"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "build": "tsdown src/OsmProcessor.ts"
   },
   "type": "module"
 }

--- a/common-lib/package.json
+++ b/common-lib/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "transitopia-lib",
+  "peerDependencies": {
+    "zod": "4"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "type": "module"
+}

--- a/common-lib/src/FeatureId.test.ts
+++ b/common-lib/src/FeatureId.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  type CyclingWayId,
+  type BicycleParkingId,
+  parseIdString,
+} from "./FeatureId.ts";
+import { assertType } from "./utils/type-asserts.ts";
+
+test("CyclingWayId", async (t) => {
+  // ✅ valid cycling way IDs:
+  for (const strInput of [
+    "cycling/way/2342235",
+    "cycling/way/way:2342235",
+    "cycling/way/osm:way:2342235",
+  ] as const) {
+    await t.test(`parse "${strInput}"`, () => {
+      const parsed = parseIdString(strInput);
+      assert.deepStrictEqual(parsed, {
+        domain: "cycling",
+        type: "way",
+        source: "osm",
+        namespace: "way",
+        identifier: "2342235",
+      });
+      // Because we used constant strings, TypeScript knows that the result is a Cycling Way ID:
+      assertType<CyclingWayId>(parsed);
+    });
+  }
+  // ❌ Invalid cycling way IDs:
+  for (const strInput of [
+    "cycling/way/notanumber",
+    "cycling/way/way:notanumber",
+    "cycling/way/foo:12345667",
+    "cycling/way/osm:foo:12345667",
+    "cycling/way/foo:way:12345667",
+  ] as const) {
+    await t.test(`parse "${strInput}" fails`, () => {
+      assert.throws(
+        () => {
+          parseIdString(strInput);
+        },
+        { name: "ZodError" },
+      );
+    });
+  }
+});
+
+test("BicycleParkingId", async (t) => {
+  // ✅ valid bicycle parking location (node) IDs:
+  for (const strInput of [
+    "cycling/parking/node:12345667",
+    "cycling/parking/osm:node:12345667",
+  ] as const) {
+    await t.test(`parse "${strInput}"`, () => {
+      const parsed = parseIdString(strInput);
+      assert.deepStrictEqual(parsed, {
+        domain: "cycling",
+        type: "parking",
+        source: "osm",
+        namespace: "node",
+        identifier: "12345667",
+      });
+      assertType<BicycleParkingId>(parsed);
+    });
+  }
+  // ✅ valid bicycle parking area (way) IDs:
+  for (const strInput of [
+    "cycling/parking/way:12345667",
+    "cycling/parking/osm:way:12345667",
+  ] as const) {
+    await t.test(`parse "${strInput}"`, () => {
+      const parsed = parseIdString(strInput);
+      assert.deepStrictEqual(parsed, {
+        domain: "cycling",
+        type: "parking",
+        source: "osm",
+        namespace: "way",
+        identifier: "12345667",
+      });
+      assertType<BicycleParkingId>(parsed);
+    });
+  }
+  // ❌ Invalid bicycle parking IDs:
+  for (const strInput of [
+    "cycling/parking/12345667",
+    "cycling/parking/way:notanumber",
+    "cycling/parking/foo:12345667",
+    "cycling/parking/osm:foo:12345667",
+    "cycling/parking/foo:way:12345667",
+  ] as const) {
+    await t.test(`parse "${strInput}" fails`, () => {
+      assert.throws(
+        () => {
+          parseIdString(strInput);
+        },
+        { name: "ZodError" },
+      );
+    });
+  }
+});

--- a/common-lib/src/FeatureId.ts
+++ b/common-lib/src/FeatureId.ts
@@ -1,0 +1,181 @@
+/**
+ * Our overly-complicated FeatureId format.
+ *
+ * A FeatureId is a unique Identifier for anything that can appear on the map,
+ * and perhaps even abstract things like "schedules" that can't exactly be mapped
+ * but are nevertheless part of Transitopia.
+ *
+ * The basic format of a FeatureId is designed to exaclty match what users see in
+ * the URL, e.g.
+ *    /cycling/way/123890
+ * for a bike lane, which would be accessed at https://www.transitopia.org/cycling/way/123890
+ *
+ * The main thing about FeatureIds is that we always try to just re-use the "main"
+ * external identifier. So for bike lanes, we always use the OpenStreetMap "way" ID
+ * and so on.
+ *
+ * However, sometimes we need to namespace our IDs. For example, bike parking spaces
+ * come primarily from OpenStreetMap, but there are separate namespaces for them:
+ * "node" bike parking spaces and "way" bike parking areas. Because the ID numbers
+ * are only unique within each namespace, we have to distinguish them like this:
+ *    /cycling/parking/node:123890
+ *    /cycling/parking/way:123890   (a totally different bike parking area)
+ *
+ * And then, we may in the future have data coming in from other sources than the
+ * "main" source for a given type, so we support a "source" prefix like this:
+ *    /cycling/station/gbfs:vancouver:123325
+ *    /cycling/station/other_source:vancouver:acbdef
+ *
+ * So the full breakdown is:
+ *    /domain/type/source:namespace:identifier
+ *
+ * Where source and/or namespace are often optional, depending on the domain+type.
+ * If source is included, namespace is always required.
+ */
+import * as z from "zod";
+
+export const FeatureDomain = {
+  /** Cycling and micromobility */
+  Cycling: "cycling",
+  /** Public Transit */
+  Transit: "transit",
+} as const;
+const FeatureDomainEnum = z.enum(FeatureDomain);
+export type FeatureDomain = z.infer<typeof FeatureDomainEnum>;
+
+/** The meaning of these feature types depends on the domain */
+export const FeatureType = {
+  Way: "way",
+  Parking: "parking",
+  Route: "route",
+  Station: "station",
+  Bike: "bike",
+} as const;
+const FeatureTypeEnum = z.enum(FeatureType);
+export type FeatureType = z.infer<typeof FeatureTypeEnum>;
+
+export const FeatureSource = {
+  /** OpenStreetMap */
+  Osm: "osm",
+  /** General Transit Feed Specification */
+  Gtfs: "gtfs",
+  /** General Bikeshare Feed Specification  */
+  Gbfs: "gbfs",
+} as const;
+const FeatureSourceEnum = z.enum(FeatureSource);
+export type FeatureSource = z.infer<typeof FeatureSourceEnum>;
+
+/** The three types of features used on OpenStreetMap: Node, Way, and Relation */
+export const OsmFeatureNamespace = {
+  Node: "node",
+  Way: "way",
+  Relation: "relation",
+} as const;
+const OsmFeatureNamespaceEnum = z.enum(OsmFeatureNamespace);
+export type OsmFeatureNamespace = z.infer<typeof OsmFeatureNamespaceEnum>;
+
+/** A bike lane / bike track */
+const CyclingWayId = z.object({
+  domain: z.literal(FeatureDomain.Cycling),
+  type: z.literal(FeatureType.Way),
+  source: z.literal(FeatureSource.Osm).default(FeatureSource.Osm),
+  namespace: z
+    .literal(OsmFeatureNamespace.Way)
+    .default(OsmFeatureNamespace.Way),
+  identifier: z.string().regex(/^\d+$/),
+});
+export type CyclingWayId = z.infer<typeof CyclingWayId>;
+
+/** A bike parking spot */
+const BicycleParkingId = z.object({
+  domain: z.literal(FeatureDomain.Cycling),
+  type: z.literal(FeatureType.Parking),
+  source: z.literal(FeatureSource.Osm).default(FeatureSource.Osm),
+  namespace: z.union([
+    z.literal(OsmFeatureNamespace.Node),
+    z.literal(OsmFeatureNamespace.Way),
+  ]),
+  identifier: z.string().regex(/^\d+$/),
+});
+export type BicycleParkingId = z.infer<typeof BicycleParkingId>;
+
+/** A bike route, e.g. "Central Valley Greenway" - a path made of many CyclingWay segments */
+const CyclingRouteId = z.object({
+  domain: z.literal(FeatureDomain.Cycling),
+  type: z.literal(FeatureType.Route),
+  source: z.literal(FeatureSource.Osm).default(FeatureSource.Osm),
+  namespace: z
+    .literal(OsmFeatureNamespace.Relation)
+    .default(OsmFeatureNamespace.Relation),
+  identifier: z.string().regex(/^\d+$/),
+});
+export type CyclingRouteId = z.infer<typeof CyclingRouteId>;
+
+const CyclingFeatureId = z.discriminatedUnion("type", [
+  CyclingWayId,
+  CyclingRouteId,
+  BicycleParkingId,
+]);
+
+const TransitRouteId = z.object({
+  domain: z.literal(FeatureDomain.Transit),
+  type: z.literal(FeatureType.Route),
+  source: z.literal(FeatureSource.Gtfs).default(FeatureSource.Gtfs),
+  namespace: z.string(),
+  identifier: z.string().regex(/^\d+$/),
+});
+const TransitStationId = z.object({
+  domain: z.literal(FeatureDomain.Transit),
+  type: z.literal(FeatureType.Station),
+  source: z.literal(FeatureSource.Gtfs).default(FeatureSource.Gtfs),
+  namespace: z.string(),
+  identifier: z.string().regex(/^\d+$/),
+});
+
+const TransitFeatureId = z.discriminatedUnion("type", [
+  TransitRouteId,
+  TransitStationId,
+]);
+
+export const FeatureId = z.discriminatedUnion("domain", [
+  CyclingFeatureId,
+  TransitFeatureId,
+]);
+export type FeatureId = z.infer<typeof FeatureId>;
+
+// Make parseIdString() return a specific FeatureId subclass if it can
+export function parseIdString<
+  D extends FeatureDomain = FeatureDomain,
+  T extends FeatureType = FeatureType,
+>(idStr: `${D}/${T}/${string}`): FeatureId & { domain: D; type: T };
+
+export function parseIdString(idStr: string): FeatureId;
+
+export function parseIdString(idStr: string) {
+  const [domain, type, sourceNamespaceIdentifier, ...rest] = idStr.split("/");
+  if (rest.length !== 0) {
+    throw new Error(`Invalid ID "${idStr}": unexpected "/"`);
+  }
+  const [first, second, ...idParts] = sourceNamespaceIdentifier.split(":");
+  let source: string | undefined,
+    namespace: string | undefined,
+    identifier: string | undefined;
+  if (idParts.length > 0) {
+    source = first;
+    namespace = second;
+    identifier = idParts.join(":");
+  } else if (second !== undefined) {
+    namespace = first;
+    identifier = second;
+  } else {
+    identifier = first;
+  }
+  return FeatureId.parse({
+    domain,
+    type,
+    source,
+    namespace,
+    identifier,
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+}

--- a/common-lib/src/FeatureId.ts
+++ b/common-lib/src/FeatureId.ts
@@ -7,7 +7,7 @@
  *
  * The basic format of a FeatureId is designed to exaclty match what users see in
  * the URL, e.g.
- *    /cycling/way/123890
+ *    cycling/way/123890
  * for a bike lane, which would be accessed at https://www.transitopia.org/cycling/way/123890
  *
  * The main thing about FeatureIds is that we always try to just re-use the "main"
@@ -18,16 +18,16 @@
  * come primarily from OpenStreetMap, but there are separate namespaces for them:
  * "node" bike parking spaces and "way" bike parking areas. Because the ID numbers
  * are only unique within each namespace, we have to distinguish them like this:
- *    /cycling/parking/node:123890
- *    /cycling/parking/way:123890   (a totally different bike parking area)
+ *    cycling/parking/node:123890
+ *    cycling/parking/way:123890   (a totally different bike parking area)
  *
  * And then, we may in the future have data coming in from other sources than the
  * "main" source for a given type, so we support a "source" prefix like this:
- *    /cycling/station/gbfs:vancouver:123325
- *    /cycling/station/other_source:vancouver:acbdef
+ *    cycling/station/gbfs:vancouver:123325
+ *    cycling/station/other_source:vancouver:acbdef
  *
  * So the full breakdown is:
- *    /domain/type/source:namespace:identifier
+ *    domain/type/source:namespace:identifier
  *
  * Where source and/or namespace are often optional, depending on the domain+type.
  * If source is included, namespace is always required.

--- a/common-lib/src/MapFeatures.ts
+++ b/common-lib/src/MapFeatures.ts
@@ -19,6 +19,11 @@ type CyclingComfort = (typeof CyclingComfort)[keyof typeof CyclingComfort];
 export interface MapCyclingWay {
   type: "cycling/way";
   osm_way_id?: number;
+  /**
+   * For features made from merging multiple similar OSM ways, this is a comma separated
+   * string of the constituent OSM Way IDs. e.g. `"5677418962,12079149472,12079149502"`
+   */
+  osm_way_ids?: string;
   name?: string;
   construction?: boolean;
   shared_with_pedestrians: boolean;
@@ -32,6 +37,11 @@ export interface MapCyclingWay {
   oneway: 0 | 1 | -1;
   /** If there's a cycle lane on only one side of the road, which side? */
   side?: "right" | "left";
+  /**
+   * IDs of OpenStreetMap relations that define routes that include this way.
+   * Comma separated string. e.g. `"1620209,19316878"`
+   */
+  routes?: string;
 
   // Mostly for things under construction:
   website?: string;

--- a/common-lib/src/MapFeatures.ts
+++ b/common-lib/src/MapFeatures.ts
@@ -1,0 +1,39 @@
+export const CyclingComfort = {
+  /** A fully separated bike track that's off-street or has a physical barrier separating it from traffic */
+  MOST: 4,
+  /** e.g. shared lane on a quiet neighborhood street */
+  HIGH: 3,
+  /** e.g. a painted bike lane, but not separated from traffic */
+  LOW: 2,
+  /** e.g. a shared use lane on a busy street */
+  LEAST: 1,
+} as const;
+type CyclingComfort = (typeof CyclingComfort)[keyof typeof CyclingComfort];
+
+/**
+ * Data included for cycling tracks/lanes in the Transitopia Cycling layer of our map.
+ *
+ * Can also be loaded directly from the OpenStreetMap API by parsing the Way's tag data
+ * with `deriveCyclingTags()`.
+ */
+export interface MapCyclingWay {
+  type: "cycling/way";
+  osm_way_id?: number;
+  name?: string;
+  construction?: boolean;
+  shared_with_pedestrians: boolean;
+  shared_with_vehicles: boolean;
+  dooring_risk?: boolean;
+  /** Surface, i.e. paved or not. */
+  surface?: string;
+  /** A cycle *track* is separate from the road (off-road). A lane is part of a road. */
+  class: "lane" | "track";
+  comfort: CyclingComfort;
+  oneway: 0 | 1 | -1;
+  /** If there's a cycle lane on only one side of the road, which side? */
+  side?: "right" | "left";
+
+  // Mostly for things under construction:
+  website?: string;
+  opening_date?: string;
+}

--- a/common-lib/src/OsmProcessor.ts
+++ b/common-lib/src/OsmProcessor.ts
@@ -1,0 +1,296 @@
+/**
+ * OsmProcessor contains shared logic used both when generating the map, and when loading
+ * data on-demand from OpenStreetMap. For example, the logic for how to compute the "comfort
+ * level" of a bike lane is here, because we need it both when generating the map and when
+ * the URL contains the ID of a specific bike lane to display, which we don't yet know how
+ * to load from the map (we don't know which tile it's in).
+ */
+
+import { CyclingComfort, type MapCyclingWay } from "./MapFeatures";
+import type { OsmTagRecord } from "./OsmTagSchema";
+
+const tagIsOneOf = (
+  tag: string | undefined,
+  ...values: (string | undefined)[]
+): boolean => values.includes(tag);
+/** Safely parse a string as an integer, returning undefined if it's invalid */
+const safeParseInt = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const intValue = parseInt(value, 10);
+  return Number.isFinite(intValue) ? intValue : undefined;
+};
+
+export function deriveCyclingTags(
+  osmWayId: number,
+  rawOsmTags: OsmTagRecord,
+): MapCyclingWay | undefined {
+  const tags = rawOsmTags;
+
+  const common: Pick<
+    MapCyclingWay,
+    "type" | "osm_way_id" | "name" | "surface"
+  > = {
+    type: "cycling/way",
+    osm_way_id: osmWayId,
+  };
+  if (tags.name) {
+    common.name = tags.name;
+  }
+  if (tags.surface) {
+    common.surface = tags.surface;
+  }
+
+  // "OSM distinguishes between cycle "lanes" and cycle "tracks":
+  // A cycle *track* is separate from the road (off-road).
+  // Tracks are typically separated from the road by e.g. curbs, parking lots, grass verges, trees, etc."
+
+  if (tags.highway === "cycleway") {
+    // A track that is primarily for cycling, totally separate from road users
+    const shared_with_pedestrians =
+      tags.foot === "designated" && tags.segregated === "no";
+    return {
+      ...common,
+      class: "track",
+      shared_with_pedestrians,
+      shared_with_vehicles: false,
+      comfort:
+        shared_with_pedestrians ? CyclingComfort.HIGH : CyclingComfort.MOST,
+      oneway:
+        tags.oneway === "yes" ? 1
+        : tags.oneway === "-1" ? -1
+        : 0,
+    };
+  } else if (
+    tagIsOneOf(tags.highway, "path", "pedestrian")
+    && tags.bicycle === "designated"
+  ) {
+    // A track that is primarily for pedestrians, but allows cycling, and is totally separate from road users
+    const shared_with_pedestrians =
+      (tags.foot === "designated" || tags.highway === "pedestrian")
+      && tags.segregated !== "yes";
+    return {
+      ...common,
+      class: "track",
+      shared_with_pedestrians,
+      shared_with_vehicles: false,
+      comfort:
+        shared_with_pedestrians ? CyclingComfort.HIGH : CyclingComfort.MOST,
+      oneway:
+        tags.oneway === "yes" ? 1
+        : tags.oneway === "-1" ? -1
+        : 0,
+    };
+  } else if ("highway" in tags && tags.cycleway === "track") {
+    // a cycle way that is parallel to and next to the road, but is separated from traffic.
+    const shared_with_pedestrians =
+      tags.foot === "designated" && tags.segregated !== "yes";
+    return {
+      ...common,
+      class: "track",
+      shared_with_pedestrians,
+      shared_with_vehicles: false,
+      comfort:
+        shared_with_pedestrians ? CyclingComfort.HIGH : CyclingComfort.MOST,
+      oneway:
+        tags.oneway === "yes" ? 1
+        : tags.oneway === "-1" ? -1
+        : 0,
+    };
+  } else if (
+    tags.highway === "construction"
+    && tags.construction === "cycleway"
+  ) {
+    // A bike track that is closed for construction
+    const shared_with_pedestrians =
+      tags.foot === "designated" && tags.segregated !== "yes";
+    return {
+      ...common,
+      class: "track",
+      construction: true,
+      shared_with_pedestrians,
+      shared_with_vehicles: false,
+      comfort:
+        shared_with_pedestrians ? CyclingComfort.HIGH : CyclingComfort.MOST,
+      oneway:
+        tags.oneway === "yes" ? 1
+        : tags.oneway === "-1" ? -1
+        : 0,
+      ...(tags.website ? { website: tags.website } : undefined),
+      ...(tags.opening_date ? { opening_date: tags.opening_date } : undefined),
+    };
+  } else if (
+    tags.highway
+    && tags.oneway !== "yes"
+    && (tags.cycleway === "lane"
+      || tags["cycleway:both"] === "lane"
+      || (tags["cycleway:left"] === "lane"
+        && tags["cycleway:right"] === "lane"))
+  ) {
+    // A road with regular bike *lanes* that lie on within the roadway itself, one on each side.
+    let dooringRisk = false;
+    // Check for dooring risk:
+    if (
+      tagIsOneOf(tags.parking, "lane", "street_side")
+      || tagIsOneOf(tags["parking:both"], "lane", "street_side")
+    ) {
+      // TODO: should we ignore if "parking:[side]:orientation" is "diagonal" or "perpendicular" ?
+      dooringRisk = true;
+    } else if (tags["parking:both"] === "separate") {
+      // The parking is a separate OSM way, so theoretically we'd need to implement
+      // preprocessOsmWay() to create a list of nearby parking areas first similar to
+      // https://github.com/onthegomap/planetiler/discussions/1071#discussioncomment-10988131
+      // to identify the specific parking area and check if it has orientation=parallel and
+      // parking=street_side or parking=lane... but so far I've only found a few instances
+      // of this alongside bike lanes in BC and they're all dooring risks (no false
+      // positives we need to filter out).
+      dooringRisk = true;
+    } else if (
+      tagIsOneOf(tags["parking:right"], "separate", "lane", "street_side")
+      || tagIsOneOf(tags["parking:right"], "separate", "lane", "street_side")
+    ) {
+      // This is a complex case that we don't yet handle well - the bike lane in one direction
+      // is fine, but in the other direction has a dooring risk. So since we're only showing
+      // one line for both directions, we downgrade this whole segment of the route.
+      // Also see note above about how "separate" might need to be further filtered.
+      dooringRisk = true;
+    }
+
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: false,
+      shared_with_vehicles: false,
+      comfort: dooringRisk ? CyclingComfort.LEAST : CyclingComfort.LOW,
+      oneway: 0,
+      ...(dooringRisk ? { dooring_risk: true } : undefined),
+    };
+  } else if (
+    tags.highway
+    && tags.oneway !== "yes"
+    && ((tags["cycleway:right"] === "lane"
+      && tags["cycleway:right:oneway"] === "no")
+      || (tags["cycleway:left"] === "lane"
+        && tags["cycleway:left:oneway"] === "no"))
+  ) {
+    // A two-way bike lane on one side of the roadway, not separated from traffic
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: false,
+      shared_with_vehicles: false,
+      comfort: CyclingComfort.LOW,
+      oneway: 0,
+      side: tags["cycleway:right"] === "lane" ? "right" : "left",
+    };
+  } else if (
+    tags.highway
+    && tags.oneway === "yes"
+    && (tags.cycleway === "lane"
+      || tags["cycleway:right"] === "lane"
+      || tags["cycleway:left"] === "lane")
+  ) {
+    // A one-way bike lane on a one-way roadway, not separated from traffic
+    const side = tags["cycleway:left"] === "lane" ? "left" : "right";
+    let dooringRisk = false;
+    if (
+      tagIsOneOf(tags[`parking:${side}`], "separate", "lane", "street_side")
+    ) {
+      // The bike lane is adjacent to parking
+      // TODO: need some way to negate this if there is a buffer between the bike lane and
+      // the parking lane. But https://wiki.openstreetmap.org/wiki/Key:cycleway:buffer is
+      // explicitly only for a buffer between the bike lane and cars.
+      // Can possibly use "cycleway:right:separation:right" etc. per
+      // https://wiki.openstreetmap.org/wiki/Proposal:Separation but this doesn't have
+      // much adoption.
+      // Also see note above about how "separate" might need to be further filtered.
+      dooringRisk = true;
+    }
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: false,
+      shared_with_vehicles: false,
+      comfort: dooringRisk ? CyclingComfort.LEAST : CyclingComfort.LOW,
+      // Default is one way like the "parent" roadway
+      oneway:
+        // In rare cases, there is a bike lane on both sides of a one way street.
+        // In even rarer cases, there is some other exotic lane type on one side, but we ignore that for now.
+        tags["cycleway:right"] === "lane" && tags["cycleway:left"] === "lane" ?
+          0
+        : (
+          tags["cycleway:left"] === "lane" && tags["cycleway:right"] === "lane"
+        ) ?
+          0
+        : 1,
+      side,
+      ...(dooringRisk ? { dooring_risk: true } : undefined),
+    };
+  } else if (
+    (tags.highway && tagIsOneOf(tags.cycleway, "shared_lane", "shared"))
+    || tagIsOneOf(tags["cycleway:both"], "shared_lane", "shared")
+  ) {
+    // A lane that is shared with motor vehicles
+    let maxSpeed = safeParseInt(tags.maxspeed);
+
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: false,
+      shared_with_vehicles: true,
+      comfort:
+        tags.motor_vehicle === "private" ? CyclingComfort.HIGH
+        : maxSpeed && maxSpeed <= 30 ? CyclingComfort.HIGH
+        : CyclingComfort.LEAST,
+      oneway:
+        tags["oneway:bicycle"] === "no" ? 0
+        : tags.oneway === "yes" ? 1
+        : 0,
+    };
+  } else if (
+    tags.highway === "residential"
+    && tagIsOneOf(tags.bicycle, "yes", "designated")
+    && safeParseInt(tags.maxspeed) !== undefined
+    && safeParseInt(tags.maxspeed)! <= 30
+  ) {
+    // A slow street that bicycles can use
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: tags.foot === "yes",
+      shared_with_vehicles: true,
+      comfort: CyclingComfort.HIGH,
+      oneway:
+        tags["oneway:bicycle"] === "no" ? 0
+        : tags.oneway === "yes" ? 1
+        : 0,
+    };
+  } else if (
+    tags.highway
+    && ((tags["cycleway:right"] === "lane" && tags["cycleway:left"] === "no")
+      || (tags["cycleway:left"] === "lane" && tags["cycleway:right"] === "no"))
+  ) {
+    // The street is a two-way street but the bike lane is a one-way bike lane on one side only.
+    // "L2" on https://wiki.openstreetmap.org/wiki/Bicycle (highway=* + cycleway:right=lane)
+    const side = tags["cycleway:left"] === "lane" ? "left" : "right";
+    let dooringRisk = false;
+    if (
+      tagIsOneOf(tags["parking:both"], "separate", "lane", "street_side")
+      || tagIsOneOf(tags[`parking:${side}`], "separate", "lane", "street_side")
+    ) {
+      dooringRisk = true;
+    }
+    return {
+      ...common,
+      class: "lane",
+      shared_with_pedestrians: false,
+      shared_with_vehicles: false,
+      comfort: dooringRisk ? CyclingComfort.LEAST : CyclingComfort.LOW,
+      oneway: tags["cycleway:left"] === "lane" ? -1 : 1,
+      side,
+      ...(dooringRisk ? { dooring_risk: true } : undefined),
+    };
+  }
+  // TODO: support other types of cycle paths
+  // TODO: support "T2 (alternative)" on https://wiki.openstreetmap.org/wiki/Bicycle (cycleway:right=track + cycleway:right:oneway=no)
+  // e.g. https://www.openstreetmap.org/way/74096518 (mixed lane + shared_lane)
+}

--- a/common-lib/src/OsmTagSchema.ts
+++ b/common-lib/src/OsmTagSchema.ts
@@ -1,0 +1,200 @@
+/**
+ * This file defines all the possible values of OpenStreetMap feature
+ * tags that we may encounter, in the simplest terms. It defines the
+ * common, known values and also clarifies that there may be unexpected
+ * values for any given key ("string" type).
+ *
+ * This is purely a type-checking feature and has NO runtime code.
+ */
+
+/* Generic placeholder for any value type we're not expecting */
+type OtherValueStr = string & { __brand: "Other Value" };
+type NumericValue = `${number}`;
+type BoolStr = "yes" | "no";
+
+type CyclewayValues =
+  | "no"
+  | "lane"
+  | "crossing"
+  | "shared_lane"
+  | "share_busway"
+  | "track"
+  | "separate"
+  | OtherValueStr;
+type ParkingValues =
+  | "yes"
+  | "no"
+  | "lane"
+  | "street_side"
+  | "separate"
+  | "half_on_kerb"
+  | "on_kerb"
+  | "no_parking"
+  | "parallel"
+  | "shoulder"
+  | OtherValueStr;
+
+export interface OsmTagRecord {
+  /**
+   * `bicycle` specifies legal restriction for cyclists when used on roads and paths.
+   * https://wiki.openstreetmap.org/wiki/Key:bicycle
+   */
+  bicycle?:
+    | BoolStr
+    | "designated"
+    | "use_sidepath"
+    | "dismount"
+    | "permissive"
+    | "private"
+    | OtherValueStr;
+  /**
+   * Clarifies which part of the feature is under construction
+   * https://wiki.openstreetmap.org/wiki/Key:construction
+   */
+  construction?:
+    | "yes"
+    | "residential"
+    | "house"
+    | "motorway"
+    | "minor"
+    | "rail"
+    | "service"
+    | "motorway_link"
+    | "tertiary"
+    | "apartments"
+    | "secondary"
+    | "trunk"
+    | "footway"
+    | "primary"
+    | "unclassified"
+    | "building"
+    | "shed"
+    | "industrial"
+    | "cycleway"
+    | "path"
+    | "subway"
+    | OtherValueStr;
+  /**
+   * Describes cycling infrastructure that is an inherent part of the road,
+   * usually bike lanes that are part of the road, directly alongside traffic.
+   * https://wiki.openstreetmap.org/wiki/Key:cycleway
+   */
+  cycleway?: CyclewayValues;
+  "cycleway:both"?: CyclewayValues;
+  "cycleway:left"?: CyclewayValues;
+  "cycleway:left:oneway"?: "yes" | "no" | "-1" | OtherValueStr;
+  "cycleway:right"?: CyclewayValues;
+  "cycleway:right:oneway"?: "yes" | "no" | "-1" | OtherValueStr;
+  /**
+   * Legal access restriction for pedestrians when used on roads and paths.
+   * https://wiki.openstreetmap.org/wiki/Key:foot
+   */
+  foot?:
+    | BoolStr
+    | "designated"
+    | "permissive"
+    | "use_sidepath"
+    | "private"
+    | OtherValueStr;
+  /**
+   * `highway=*` is the main key used for identifying any kind of road, street or path.
+   * https://wiki.openstreetmap.org/wiki/Key:highway
+   */
+  highway?:
+    | "residential"
+    | "service"
+    | "track"
+    | "footway"
+    | "unclassified"
+    | "path"
+    | "crossing"
+    | "tertiary"
+    | "secondary"
+    | "pedestrian"
+    | "cycleway"
+    | "construction"
+    | OtherValueStr;
+  /**
+   * Total number of traffic lanes available for motorised traffic.
+   * https://wiki.openstreetmap.org/wiki/Key:lanes
+   */
+  lanes?: NumericValue | OtherValueStr;
+  /**
+   * Maximum speed (speed limit), in km/h unless a unit is given.
+   * https://wiki.openstreetmap.org/wiki/Key:maxspeed
+   */
+  maxspeed?: `${number}` | `${number} ${string}` | "none" | OtherValueStr;
+  /**
+   * Access restrictions for motor vehicles
+   * https://wiki.openstreetmap.org/wiki/Key:motor_vehicle
+   */
+  motor_vehicle?:
+    | "no"
+    | "yes"
+    | "private"
+    | "destination"
+    | "agricultural"
+    | "forestry"
+    | "designated"
+    | "permit"
+    | "permissive"
+    | OtherValueStr;
+  /**
+   * This key is set to the primary name of the feature in the real world.
+   * https://wiki.openstreetmap.org/wiki/Key:name
+   */
+  name?: string;
+  /**
+   * Linear features that users can only go one direction in.
+   * https://wiki.openstreetmap.org/wiki/Key:oneway
+   */
+  oneway?: BoolStr | "-1" | OtherValueStr;
+  "oneway:bicycle"?: BoolStr | "-1" | OtherValueStr;
+  /**
+   * When a feature under construction will be opened.
+   * Should be in `YYYY-MM-DD` format.
+   * https://wiki.openstreetmap.org/wiki/Key:opening_date
+   */
+  opening_date?: string;
+  /**
+   * What kind of parking is available. Generally prefer `parking:both`,
+   * `parking:left`, or `parking:right`.
+   * https://wiki.openstreetmap.org/wiki/Key:parking
+   */
+  parking?: ParkingValues;
+  "parking:both"?: ParkingValues;
+  "parking:left"?: ParkingValues;
+  "parking:right"?: ParkingValues;
+  /**
+   * `segregated` describes designated combined cycle- and footways.
+   * If both have their own lane, `segregated=yes`.
+   * If they share one lane, `segregated=no`.
+   * https://wiki.openstreetmap.org/wiki/Key:segregated
+   */
+  segregated?: BoolStr | OtherValueStr;
+  /**
+   * Describes the surface of a feature (paved, dirt, etc.).
+   * https://wiki.openstreetmap.org/wiki/Key:surface
+   */
+  surface?:
+    | "paved"
+    | "unpaved"
+    | "asphalt"
+    | "concrete"
+    | "paving_stones"
+    | "ground"
+    | "gravel"
+    | "dirt"
+    | "grass"
+    | "compacted"
+    | "sand"
+    | "sett"
+    | "fine_gravel"
+    | "wood"
+    | OtherValueStr;
+  /**
+   * Official website with information about a feature.
+   * https://wiki.openstreetmap.org/wiki/Key:website
+   */
+  website?: string;
+}

--- a/common-lib/src/utils/type-asserts.ts
+++ b/common-lib/src/utils/type-asserts.ts
@@ -1,0 +1,105 @@
+//========== About this module ==========
+
+// This is https://github.com/rauschma/asserttt/blob/main/src/asserttt.ts
+// By Axel Rauschmayer
+
+// MIT License
+
+// Copyright (c) 2025 Axel Rauschmayer
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//========== Asserting ==========
+
+/**
+ * - Is type `_T` assignable to `true`
+ * - Based on code by Blaine Bublitz.
+ */
+export type Assert<_T extends true> = void;
+
+/**
+ * Is the type of `_value` assignable to `T`?
+ */
+export function assertType<T>(_value: T): void {}
+
+//========== Predicates: equality ==========
+
+/**
+ * - Is type `X` equal to type `Y` (with `any` only being equal to itself)?
+ * - Name motivated by Node’s assert.equal().
+ * - Like `MutuallyAssignable` but `any` is only equal to itself.
+ */
+export type Equal<X, Y> = [IsAny<X>, IsAny<Y>] extends [true, true] ? true
+  : [IsAny<X>, IsAny<Y>] extends [false, false] ? MutuallyAssignable<X, Y>
+  : false;
+
+/**
+ * - The brackets on the left-hand side of `extends` prevent
+ *   distributivity.
+ */
+export type MutuallyAssignable<X, Y> = [X, Y] extends [Y, X] ? true : false;
+
+/**
+ * - Name motivated by Node’s assert.deepEqual().
+ * - Source: https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+ */
+export type PedanticEqual<X, Y> = (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2) ? true : false;
+
+//========== Predicates: comparing types ==========
+
+/**
+ * - Does type `Sub` extend type `Super`?
+ * - Square brackets around `Sub` prevent distributivity (`Super` is also
+ *   in brackets so that the test works).
+ */
+export type Extends<Sub, Super> = [Sub] extends [Super] ? true : false;
+
+/**
+ * - Is type `Target` assignable from type `Source`?
+ * - Square brackets around `Source` prevent distributivity (`Target` is
+ *   also in brackets so that the test works).
+ */
+export type Assignable<Target, Source> = [Source] extends [Target] ? true
+  : false;
+
+/**
+ * - Is type `Subset` a subset of type `Superset`?
+ * - Square brackets around `Subset` prevent distributivity (`Superset` is
+ *   also in brackets so that the test works).
+ */
+export type Includes<Superset, Subset> = [Subset] extends [Superset] ? true
+  : false;
+
+//========== Predicates: boolean operations ==========
+
+/**
+ * Boolean NOT for type `B`.
+ */
+export type Not<B extends boolean> =
+  // `Equal` because want to avoid Not<any> being `false` or `true`
+  Equal<B, true> extends true ? false
+    : (Equal<B, false> extends true ? true : never);
+
+//========== Predicates: other ==========
+
+/**
+ * - Source: https://stackoverflow.com/questions/49927523/disallow-call-with-any/49928360#49928360
+ */
+export type IsAny<T> = 0 extends (1 & T) ? true : false;

--- a/common-lib/tsconfig.json
+++ b/common-lib/tsconfig.json
@@ -2,20 +2,18 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "bundler",
+    "noEmit": true, // We'll use tsdown if we need to bundle this
+    "skipLibCheck": true,
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
     "strict": true,
+    "isolatedModules": true,
     "exactOptionalPropertyTypes": true, // Distinguish between {key?: value} and {key: value | undefined} strictly.
     "erasableSyntaxOnly": true, // Allow running code directly with Node.
     "verbatimModuleSyntax": true, // Allow running code directly with Node.
@@ -23,6 +21,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src"
+  ]
 }

--- a/map-layers/README.md
+++ b/map-layers/README.md
@@ -2,7 +2,8 @@
 
 This Transitopia profile for [Planetiler](https://github.com/onthegomap/planetiler) generates
 the following map layers:
-  * [Transitopia Cycling Map](https://www.transitopia.org/cycling)
+
+- [Transitopia Cycling Map](https://www.transitopia.org/cycling)
 
 ## How to use
 
@@ -18,7 +19,7 @@ Then these commands to build the profile and generate the map:
 
 ```
 rm data/sources/british_columbia.osm.pbf
-java -jar target/planetiler-*-with-deps.jar --force --download
+java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -Dpolyglot.engine.WarnInterpreterOnly=false -jar target/planetiler-*-with-deps.jar --force --download
 ```
 
 The result will be in `./data/transitopia-cycling-british-columbia.pmtiles`

--- a/map-layers/pom.xml
+++ b/map-layers/pom.xml
@@ -11,6 +11,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <planetiler.version>0.9.1</planetiler.version>
     <junit.version>5.10.1</junit.version>
+    <graaljs.version>24.1.0</graaljs.version>
 
     <mainClass>org.transitopia.TransitopiaMain</mainClass>
     <image.version>${project.version}</image.version>
@@ -20,7 +21,7 @@
 
   <groupId>org.transitopia</groupId>
   <artifactId>planetiler-transitopia</artifactId>
-  <version>25.08.10</version>
+  <version>25.08.20</version>
 
   <name>Transitopia Vector Tile Schema implementation for Planetiler tool</name>
 
@@ -57,6 +58,17 @@
       <artifactId>planetiler-core</artifactId>
       <version>${planetiler.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>polyglot</artifactId>
+      <version>${graaljs.version}</version>
+  </dependency>
+  <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>js</artifactId>
+      <version>${graaljs.version}</version>
+      <type>pom</type>
+  </dependency>
   </dependencies>
 
   <scm>

--- a/map-layers/src/main/java/org/transitopia/layers/Cycling.java
+++ b/map-layers/src/main/java/org/transitopia/layers/Cycling.java
@@ -112,11 +112,16 @@ public class Cycling implements
 
                 // If this feature is a part of any routes, record that:
                 var partOfRoutes = feature.relationInfo(RouteRelationInfo.class);
+                // Sort by ID so that we can merge similar features later when comparing their tags, including "routes"
                 if (!partOfRoutes.isEmpty()) {
+                    List<Long> sortedRoutes = partOfRoutes.stream()
+                        .map(r -> r.relation().id())
+                        .sorted()
+                        .toList();
                     var routeIdsString = "";
-                    for (var relation : partOfRoutes) {
+                    for (var relationId : sortedRoutes) {
                         if (routeIdsString != "") routeIdsString += ",";
-                        routeIdsString += relation.relation().id;
+                        routeIdsString += relationId;
                     }
                     bikePath.setAttrWithMinzoom("routes", routeIdsString, MIN_ZOOM_ATTR);
                 }

--- a/map-layers/src/main/java/org/transitopia/utils/FeatureMergeWithIds.java
+++ b/map-layers/src/main/java/org/transitopia/utils/FeatureMergeWithIds.java
@@ -1,0 +1,174 @@
+// Based on planetiler/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+// https://github.com/onthegomap/planetiler/blob/main/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java
+// Planetiler source code is licensed under the Apache 2.0 License:
+// https://github.com/onthegomap/planetiler/blob/8e33753/LICENSE
+package org.transitopia.utils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+
+import com.onthegomap.planetiler.FeatureMerge;
+import com.onthegomap.planetiler.VectorTile;
+import com.onthegomap.planetiler.geo.GeoUtils;
+import com.onthegomap.planetiler.geo.GeometryException;
+import com.onthegomap.planetiler.geo.GeometryPipeline;
+import com.onthegomap.planetiler.geo.GeometryType;
+import com.onthegomap.planetiler.geo.MutableCoordinateSequence;
+import com.onthegomap.planetiler.util.LoopLineMerger;
+
+/**
+ * A utility class for merging linear features together if they have identical attributes.
+ *
+ * Unlike the base FeatureMerge class, this does not discard [OpenSteetMap] IDs when merging
+ * features but rather creates a list of all the original IDs on the merged feature.
+ *
+ * This is modified from the base class `com.onthegomap.planetiler.FeatureMerge`; it would
+ * be nice to just extend that class but it doesn't allow extension.
+ */
+public class FeatureMergeWithIds {
+
+  // Unmodified comparator form base FeatureMerge class.
+  private static final Comparator<WithIndex<?>> BY_HILBERT_INDEX = (o1, o2) -> Integer.compare(o1.hilbert, o2.hilbert);
+
+  /**
+   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, double, double, double, boolean)}
+   * except sets {@code resimplify=false} by default.
+   */
+  public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
+    double minLength, double tolerance, double buffer) {
+    return mergeLineStrings(features, minLength, tolerance, buffer, false);
+  }
+
+  public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
+    double minLength, double tolerance, double buffer, boolean resimplify) {
+    return mergeLineStrings(features, attrs -> minLength, tolerance, buffer, resimplify, null);
+  }
+
+  /**
+   * Merges linestrings with the same attributes as {@link #mergeLineStrings(List, double, double, double, boolean)}
+   * except with a dynamic length limit computed by {@code lengthLimitCalculator} for the attributes of each group.
+   */
+  public static List<VectorTile.Feature> mergeLineStrings(List<VectorTile.Feature> features,
+    Function<Map<String, Object>, Double> lengthLimitCalculator, double tolerance, double buffer, boolean resimplify,
+    GeometryPipeline pipeline) {
+    List<VectorTile.Feature> result = new ArrayList<>(features.size());
+    var groupedByAttrs = FeatureMerge.groupByAttrs(features, result, GeometryType.LINE);
+    for (List<VectorTile.Feature> groupedFeatures : groupedByAttrs) {
+      VectorTile.Feature feature1 = groupedFeatures.getFirst();
+      double lengthLimit = lengthLimitCalculator.apply(feature1.tags());
+
+      // as a shortcut, can skip line merging only if:
+      // - only 1 element in the group
+      // - it doesn't need to be clipped
+      // - and it can't possibly be filtered out for being too short
+      // - and it does not need to be simplified
+      if (groupedFeatures.size() == 1 && buffer == 0d && lengthLimit == 0 && (!resimplify || tolerance == 0)) {
+        result.add(feature1);
+      } else {
+        List<Long> mergedIds = new ArrayList<>();
+        LoopLineMerger merger = new LoopLineMerger()
+          .setTolerance(tolerance)
+          .setMergeStrokes(true)
+          .setMinLength(lengthLimit)
+          .setLoopMinLength(lengthLimit)
+          .setStubMinLength(0.5)
+          .setSegmentTransform(pipeline);
+        for (VectorTile.Feature feature : groupedFeatures) {
+          try {
+            merger.add(feature.geometry().decode());
+            mergedIds.add(feature.id());
+          } catch (GeometryException e) {
+            e.log("Error decoding vector tile feature for line merge: " + feature);
+          }
+        }
+        List<LineString> outputSegments = new ArrayList<>();
+        for (var line : merger.getMergedLineStrings()) {
+          if (buffer >= 0) {
+            removeDetailOutsideTile(line, buffer, outputSegments);
+          } else {
+            outputSegments.add(line);
+          }
+        }
+
+        if (!outputSegments.isEmpty()) {
+          outputSegments = sortByHilbertIndex(outputSegments);
+          Geometry newGeometry = GeoUtils.combineLineStrings(outputSegments);
+          VectorTile.Feature mergedFeature = feature1.copyWithNewGeometry(newGeometry);
+          // We want to store the list of OSM Way IDs, but the vector tile spec doesn't allow
+          // tag values to be a list:
+          // https://github.com/mapbox/vector-tile-spec/blob/5330dfc6ba/2.1/vector_tile.proto#L15-L28
+          // So we convert it to a comma-separated string: `owm_way_id="1234,4567"`
+          // Surprisingly, this is more efficient than a series of separate integer tags
+          // like `osm_way_id_0=1234,osm_way_id_1=4567`.
+          final String mergedIdsStr = String.join(",", mergedIds.stream().map(String::valueOf).toList());
+          mergedFeature.setTag("osm_way_ids", mergedIdsStr);
+          result.add(mergedFeature);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * UNMODIFIED private helper method from FeatureMerge class.
+   */
+  private static void removeDetailOutsideTile(LineString input, double buffer, List<LineString> output) {
+    MutableCoordinateSequence current = new MutableCoordinateSequence();
+    CoordinateSequence seq = input.getCoordinateSequence();
+    boolean wasIn = false;
+    double min = -buffer, max = 256 + buffer;
+    double x = seq.getX(0), y = seq.getY(0);
+    Envelope env = new Envelope();
+    Envelope outer = new Envelope(min, max, min, max);
+    for (int i = 0; i < seq.size() - 1; i++) {
+      double nextX = seq.getX(i + 1), nextY = seq.getY(i + 1);
+      env.init(x, nextX, y, nextY);
+      boolean nowIn = env.intersects(outer);
+      if (nowIn || wasIn) {
+        current.addPoint(x, y);
+      } else { // out
+        // wait to flush until 2 consecutive outs
+        if (!current.isEmpty()) {
+          if (current.size() >= 2) {
+            output.add(GeoUtils.JTS_FACTORY.createLineString(current));
+          }
+          current = new MutableCoordinateSequence();
+        }
+      }
+      wasIn = nowIn;
+      x = nextX;
+      y = nextY;
+    }
+
+    // last point
+    double lastX = seq.getX(seq.size() - 1), lastY = seq.getY(seq.size() - 1);
+    env.init(x, lastX, y, lastY);
+    if (env.intersects(outer) || wasIn) {
+      current.addPoint(lastX, lastY);
+    }
+
+    if (current.size() >= 2) {
+      output.add(GeoUtils.JTS_FACTORY.createLineString(current));
+    }
+  }
+
+  /**
+   * UNMODIFIED private helper method from FeatureMerge class.
+   */
+  private static <G extends Geometry> List<G> sortByHilbertIndex(List<G> geometries) {
+    return geometries.stream()
+      .map(p -> new WithIndex<>(p, VectorTile.hilbertIndex(p)))
+      .sorted(BY_HILBERT_INDEX)
+      .map(d -> d.feature)
+      .toList();
+  }
+  private record WithIndex<T>(T feature, int hilbert) {}
+}

--- a/map-layers/src/main/resources/js/OsmProcessor.js
+++ b/map-layers/src/main/resources/js/OsmProcessor.js
@@ -1,0 +1,1 @@
+../../../../../common-lib/dist/OsmProcessor.js

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -13,6 +13,7 @@
         "pmtiles": "^4.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "transitopia-lib": "file:../common-lib",
         "wouter": "^3.7.1",
         "zod": "^4.0.17"
       },
@@ -27,6 +28,16 @@
         "tailwindcss": "^4.1.12",
         "typescript": "^5.9.2",
         "vite": "npm:rolldown-vite@^7.1.4"
+      }
+    },
+    "../common-lib": {
+      "name": "transitopia-lib",
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "tsdown": "^0.14.1"
+      },
+      "peerDependencies": {
+        "zod": "4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2385,6 +2396,10 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/transitopia-lib": {
+      "resolved": "../common-lib",
+      "link": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -18,6 +18,7 @@
     "pmtiles": "^4.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "transitopia-lib": "file:../common-lib",
     "wouter": "^3.7.1",
     "zod": "^4.0.17"
   },

--- a/web-ui/src/CyclingMap/CyclingMap.tsx
+++ b/web-ui/src/CyclingMap/CyclingMap.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { type MapCyclingWay } from "transitopia-lib/MapFeatures";
 import {
   layers,
   mapSource,
@@ -7,10 +8,7 @@ import {
   pathLayerIds,
 } from "./cycling-map-layers.ts";
 import { useMap, useMapLayerEvent } from "../Map/MapUtils.ts";
-import {
-  type MapCyclingElement,
-  type MapParkingElement,
-} from "../Map/MapData.ts";
+import { type MapParkingElement } from "../Map/MapData.ts";
 import { MapOverlayWindow } from "../Map/MapOverlayWindow.tsx";
 import { InfoboxBikeParking } from "./InfoboxBikeParking.tsx";
 
@@ -39,7 +37,7 @@ export const CyclingMap: React.FC = () => {
   });
 
   const [selectedFeature, setSelectedFeature] = React.useState<
-    MapCyclingElement | MapParkingElement
+    (MapCyclingWay & { id: string }) | MapParkingElement
   >();
   const hoveredFeatureIdRef = React.useRef<string | undefined>(undefined);
 
@@ -126,9 +124,9 @@ export const CyclingMap: React.FC = () => {
       if (!map || map.getZoom() < 13 || !feature) return;
       setSelectedFeature({
         id: feature.id as string,
-        type: "cycling_way",
+        type: "cycling/way",
         ...feature.properties,
-      } as MapCyclingElement);
+      } as any as MapCyclingWay & { id: string });
     },
     [map],
   );
@@ -179,7 +177,7 @@ export const CyclingMap: React.FC = () => {
 
   return (
     <>
-      {selectedFeature?.type === "cycling_way" ?
+      {selectedFeature?.type === "cycling/way" ?
         <MapOverlayWindow className="top-24">
           <div className="flex">
             <div className="flex-1">


### PR DESCRIPTION
Working toward #12 , this PR:

* Introduces a new `transitopia-lib` folder with JS code that is shared between our map generator, our frontend, and our future backends.
* Modifies our Planetiler Cycling Profile so that it can run JS code, and moves the logic for computing "comfort level" etc. from the Java code into our new shared JS `transitopia-lib`.
    - This is required so that we can load specific OSM ways from the URL; e.g. if the user goes to https://www.transitopia.org/cycling/way/123890 in the future, we have no idea where that is on the map, so we can't initially load its data from vector tiles. But we can load it from OSM, and then process it using the shared code, to display the same information about it that we would show if you clicked on the map and we got the details from the vector tile data.


TODO:
- [ ] rename `common-lib` to `transitopia-lib` ?
- [ ] if we get a feature's coordinates from OSM, _can_ we load data by ID from the vector map layers? (at arbitrary zooms?)
- [ ] document the effect this has on tile sizes, map layer generation time, etc.
- [ ] sort OSM way IDs before combining ??